### PR TITLE
Add Support for Custom Basis Ordering and CI Tests

### DIFF
--- a/embasi/atoms_embedding_asi.py
+++ b/embasi/atoms_embedding_asi.py
@@ -274,7 +274,7 @@ class AtomsEmbed():
 
         """
 
-        with open('./'+self.outdir+'/asi.log', 'r') as output:
+        with open(self.outdir+'/asi.log', 'r') as output:
 
             lines = output.readlines()
 

--- a/embasi/atoms_embedding_asi.py
+++ b/embasi/atoms_embedding_asi.py
@@ -116,6 +116,7 @@ class AtomsEmbed():
 
     def reorder_atoms_from_embed_mask(self):
         """ Re-orders atoms to push those in embedding region 1 to the beginning
+        of the atom lists to ensure data is organised in a predictable manner.
 
         """
 

--- a/embasi/embedding.py
+++ b/embasi/embedding.py
@@ -375,6 +375,8 @@ class ProjectionEmbedding(EmbeddingBase):
             self.calculator_hl.parameters['qm_embedding_mo_localise']=".true."
         else:
             raise Exception("Invalid entry for localisation: use 'SPADE' or 'qmcode' ")
+        self.calculator_ll.parameters['override_default_empty_basis_order']=".true."
+        self.calculator_hl.parameters['override_default_empty_basis_order']=".true."
 
         self.projection = projection
         if self.projection == "level-shift":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "embasi"
-version = "0.1.1"
+version = "0.2.0"
 authors = [
         {name="Gabriel Bramley", email="BramleyG@cardiff.ac.uk"},
 ]

--- a/tests/FHI-aims/projection_embedding/serial/QM_localisation/test_qmloc.py
+++ b/tests/FHI-aims/projection_embedding/serial/QM_localisation/test_qmloc.py
@@ -1,0 +1,15 @@
+import pytest
+import os
+import sys
+
+sys.path.append(os.getcwd()+"/../../../")
+print(sys.path)
+from fhiaims_meoh_test_generator import FHIaims_projection_embedding_test
+
+def test_qmcode_localisation_serial(data_regression, tmp_path):
+
+    test = FHIaims_projection_embedding_test(localisation="qmcode", test_dir=tmp_path)
+    test.run_test()
+    test_vals = test.output_ref_values()
+    data_regression.check(test_vals)
+    

--- a/tests/FHI-aims/projection_embedding/serial/QM_localisation/test_qmloc/test_qmcode_localisation_serial.yml
+++ b/tests/FHI-aims/projection_embedding/serial/QM_localisation/test_qmloc/test_qmcode_localisation_serial.yml
@@ -1,0 +1,3 @@
+energy_values:
+  MeOH_energy: -3149.6177626449435
+  PB_corr_energy: -7.175042580909175e-15

--- a/tests/FHI-aims/projection_embedding/serial/SPADE_localisation/test_spade.py
+++ b/tests/FHI-aims/projection_embedding/serial/SPADE_localisation/test_spade.py
@@ -1,0 +1,15 @@
+import pytest
+import os
+import sys
+
+sys.path.append(os.getcwd()+"/../../../")
+print(sys.path)
+from fhiaims_meoh_test_generator import FHIaims_projection_embedding_test
+
+def test_spade_localisation_serial(data_regression, tmp_path):
+
+    test = FHIaims_projection_embedding_test(test_dir=tmp_path)
+    test.run_test()
+    test_vals = test.output_ref_values()
+    data_regression.check(test_vals)
+    

--- a/tests/FHI-aims/projection_embedding/serial/SPADE_localisation/test_spade/test_spade_localisation_serial.yml
+++ b/tests/FHI-aims/projection_embedding/serial/SPADE_localisation/test_spade/test_spade_localisation_serial.yml
@@ -1,0 +1,3 @@
+energy_values:
+  MeOH_energy: -3149.617762644943
+  PB_corr_energy: -1.7238983885184412e-13

--- a/tests/FHI-aims/projection_embedding/serial/level_shift_projection/test_level-shift.py
+++ b/tests/FHI-aims/projection_embedding/serial/level_shift_projection/test_level-shift.py
@@ -1,0 +1,15 @@
+import pytest
+import os
+import sys
+
+sys.path.append(os.getcwd()+"/../../../")
+print(sys.path)
+from fhiaims_meoh_test_generator import FHIaims_projection_embedding_test
+
+def test_level_shift_projection_serial(data_regression, tmp_path):
+
+    test = FHIaims_projection_embedding_test(projection="level-shift", test_dir=tmp_path)
+    test.run_test()
+    test_vals = test.output_ref_values()
+    data_regression.check(test_vals)
+    

--- a/tests/FHI-aims/projection_embedding/serial/level_shift_projection/test_level-shift/test_level_shift_projection_serial.yml
+++ b/tests/FHI-aims/projection_embedding/serial/level_shift_projection/test_level-shift/test_level_shift_projection_serial.yml
@@ -1,0 +1,3 @@
+energy_values:
+  MeOH_energy: -3149.617763787756
+  PB_corr_energy: 9.964886881740722e-07

--- a/tests/README
+++ b/tests/README
@@ -1,0 +1,58 @@
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+EmbASI Regression Testing Infrastructure
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+Hello! Welcome to EmbASI's regression testing infrastructure
+
+In it's current state, the regression testing is a little patchy - I am still
+getting to grips with pytest, so some things will need to be set-up manually
+until I figure out certain things (e.g., A sensible, automatic way of importing
+the compiled, QM code library from environmental variables).
+
+However, for the time being, please find instructions below for running the
+regression tests on your own machine.
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+                Set-up
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+First, install the relevant libraries required for the testing infrastructure
+
+```
+pip install -r requirements.txt
+```
+
+Then, set-up the environmental variables which point to the your compile QM
+code library (for now, only FHI-aims is implemented, so we will use this as our
+example):
+
+```
+export AIMS_LIB_PATH=<locationofaimsroot/aims.XXX.so>
+export AIMS_ROOT_DIR=<locationofaimsroot>
+```
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+            Running Tests
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+To run the tests in serial:
+
+```
+pytest
+```
+
+TODO: INTRODUCE TESTING WITH MPI - CURRENTLY THROWS AN MPI ABORT
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+       Updating reference values
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+If you have added a new test, the new values for the regression test
+will be added automatically. However, if for whatever good faith reason
+you have to update the reference values, run the following:
+
+```
+pytest --force-regen TEST_FILE
+```
+
+Afterwards, commit the update .yml file in the test directory

--- a/tests/basic_tests/test_cdll_library_load.py
+++ b/tests/basic_tests/test_cdll_library_load.py
@@ -1,0 +1,16 @@
+import pytest
+
+# Basic test for ensuring the relevant QM library is correctly loaded
+@pytest.mark.order(1)
+def test_load_aims_library():
+
+    def load_aims_library():
+        from ctypes import CDLL, RTLD_GLOBAL
+        import os
+
+        lib_path = os.environ["ASI_LIB_PATH"]
+        lib = CDLL(lib_path, mode=RTLD_GLOBAL)
+
+    load_aims_library()
+        
+        

--- a/tests/fhiaims_meoh_test_generator.py
+++ b/tests/fhiaims_meoh_test_generator.py
@@ -1,0 +1,84 @@
+from embasi.embedding import ProjectionEmbedding
+from embasi.parallel_utils import root_print
+from ase.data.s22 import s22, s26, create_s22_system
+from ase.calculators.aims import Aims, AimsProfile
+import os
+
+class FHIaims_projection_embedding_test():
+
+    def __init__(self, localisation="SPADE", projection="huzinaga", parallel=False, gc=False,
+                 calc_ll_param_dict={}, calc_hl_param_dict={}, test_dir=None, basis_dir="defaults_2020/light"):
+        # Set-up calculator parameters (similar to FHIaims Calculator for
+        # ASE) for low-level and high-level calculations. Below are the
+        # absolute minimum parameters required for normal operation.
+
+        self.calc_ll = Aims(xc='PBE', profile=AimsProfile(command="asi-doesnt-need-command"),
+                       KS_method="parallel",
+                       RI_method="LVL",
+                       collect_eigenvectors=True,
+                       density_update_method='density_matrix', # for DM export
+                       atomic_solver_xc="PBE",
+                       compute_kinetic=True,
+                       override_initial_charge_check=True,
+                       )
+        
+        for key, val in calc_ll_param_dict.items():
+            self.calculator_ll.parameters[key]=val
+
+        self.calc_hl = Aims(xc='PBE', profile=AimsProfile(command="asi-doesnt-need-command"),
+                       KS_method="parallel",
+                       RI_method="LVL",
+                       collect_eigenvectors=True,
+                       density_update_method='density_matrix', # for DM export
+                       atomic_solver_xc="PBE",
+                       compute_kinetic=True,
+                       override_initial_charge_check=True,
+                       )
+
+        for key, val in calc_hl_param_dict.items():
+            self.calculator_hl.parameters[key]=val
+
+        self.localisation = localisation
+        self.projection = projection
+        self.parallel = False
+        self.gc = False
+
+        self.test_dir=test_dir
+
+        os.environ["AIMS_SPECIES_DIR"] = os.environ["AIMS_ROOT_DIR"] + "/species_defaults/" + basis_dir
+
+    def run_test(self):
+
+        # Import dimer from s26 test set
+        methanol_dimer_idx = s26[22]
+        methanol_dimer = create_s22_system(methanol_dimer_idx)
+
+        # Great! Now let's calculate the monomer total energy
+        methanol = methanol_dimer[:6]
+
+        Projection = ProjectionEmbedding(methanol,
+                                 embed_mask=[2,1,2,2,2,1],
+                                 calc_base_ll=self.calc_ll,
+                                 calc_base_hl=self.calc_hl,
+                                 mu_val=1.e+6,
+                                 localisation=self.localisation,
+                                 projection=self.projection,
+                                 run_dir=os.path.join(self.test_dir, "MeOH_monomer"),
+                                 #gc=self.gc
+                                 #parallel=self.parallel
+                                 )
+
+        Projection.run()
+
+        self.monomer_energy_total_energy = Projection.DFT_AinB_total_energy
+        self.PB_corr = Projection.PB_corr
+
+    def output_ref_values(self):
+
+        return {
+            "energy_values": {
+                "MeOH_energy"       : self.monomer_energy_total_energy.item(),
+                "PB_corr_energy"    : self.PB_corr.item(),
+                }
+            }
+

--- a/tests/parallel_solvers/test_pdsyevx.pynull
+++ b/tests/parallel_solvers/test_pdsyevx.pynull
@@ -1,0 +1,27 @@
+import numpy as np
+import os
+from mpi4py import MPI
+from scalapack4py import ScaLAPACK4py
+from numpy.random import rand
+from ctypes import CDLL, RTLD_GLOBAL, POINTER, c_int, c_double
+from embasi.parallel_utils import root_print
+from embasi.roothan_hall_eigensolver_scalapack import pdsyevx_from_numpy_array
+
+def test_pdsyev():
+
+    libpath = os.environ['ASI_LIB_PATH']
+
+    sl = ScaLAPACK4py(CDLL(libpath, mode=RTLD_GLOBAL))
+
+    n = 5
+    a = np.arange(n*n).reshape((n,n)) * (MPI.COMM_WORLD.rank+1) if MPI.COMM_WORLD.rank==0 else None
+
+    eigvals, eigvecs = pdsyevx_from_numpy_array(a, libpath, n)
+
+    return eigvals, eigvecs
+
+eigvals, eigvecs = test_pdsyev()
+root_print(eigvals)
+root_print(eigvecs)
+
+    

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,0 +1,4 @@
+pytest
+pytest-regressions
+pytest-mpi
+pytest-order


### PR DESCRIPTION
A bit of a jumble pull request. 

We add functionality to allow more flexibility of ghost atom ordering in FHI-aims input files. Now ghost species may appear at the beginning or the end of the file without reordering the basis functions. This will maintain the ordering of data structures between different runs of atoms_embedding_object. 

Further functionality added to allow custom running directories by setting "run_dir".

Most importantly, rudimentary regression testing has been added in anticipations of setting up a Github workflow. 