### PR TITLE
Basis extrapolation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 EmbASI is a python-based wrapper for QM/QM embedding simulations using the ASI (Atomic Simulation Interface). The wrapper handles communication between QM code library calls through C-based callbacks, and imports/exports relevant matices such as density matrices and hamiltonians required for embedding schemes such as Projection-Based Embedding (PbE). Atomic information is communicated through Atomic Simulation Environment (ASE) atoms objects.
 
-# Supported QM Pakage(s)
+# Supported QM Package(s)
 
 - FHI-aims
 

--- a/embasi/workflows/extrapolation.py
+++ b/embasi/workflows/extrapolation.py
@@ -64,7 +64,7 @@ class Extrapolation:
         self.d = d
         self.alpha = alpha
 
-    def checkInParam(self, item, default, cycle):
+    def checkInParam(self, item: str, default: str, cycle: int) -> str:
         if cycle == 0:
             app_Dict = self.projection1_param.items()
         else:
@@ -123,5 +123,3 @@ class Extrapolation:
             cycle +=1
 
         return (self.results[0]*(int(self.file1)+self.d)**self.alpha - self.results[1]*(int(self.file2)+self.d)**self.alpha)/((int(self.file1) + self.d)**self.alpha-(int(self.file2)+self.d)**self.alpha)
-
-

--- a/embasi/workflows/extrapolation.py
+++ b/embasi/workflows/extrapolation.py
@@ -17,10 +17,6 @@ import typing
 class Extrapolation:
     """
 
-    E
-    E(∞) is then applied to be found.
-
-    E(∞) = E[n₁]n₁³ - E[
 
     Parameters
     ----------
@@ -43,9 +39,17 @@ class Extrapolation:
         Calculator object for layer 2
     asi_path: str
         Name of directory where ASI (Atomic Simulation Interface) is installed
+    projection1_param: dict
+        Additional parameters for the first projection
+    projection2_param: dict
+        Additional parameters for the second projection
+    d: float
+        Value used for the formula E(∞)
+    alpha: float
+        Value used for the formula E(∞)
 
     """
-    def __init__(self, file1, file2, path, atom, embed_mask, calc_ll, calc_hl, asi_path,projection1_param={},projection2_param={}):
+    def __init__(self, file1, file2, path, atom, embed_mask, calc_ll, calc_hl, asi_path,projection1_param={},projection2_param={},d=2.65,alpha=4.51):
         self.asi_path = asi_path
         os.environ["ASI_LIB_PATH"] = self.asi_path
         self.file1:str= file1
@@ -62,6 +66,8 @@ class Extrapolation:
         self.energy = []
         self.projection1_param = projection1_param
         self.projection2_param = projection2_param
+        self.d = d
+        self.alpha = alpha
 
     @property
     def extrapolate(self) -> float:
@@ -107,11 +113,6 @@ class Extrapolation:
             self.results.append(energy)
             type +=1
 
-        #return ((self.results[0] * int(self.file1) ** 3) - (self.results[1]) * int(self.file2) ** 3) / (int(self.file1)** 3 - (int(self.file2) ** 3))
-
-        d = 2.65
-        alpha = 4.51
-
-        return (self.results[0]*(int(self.file1)+d)**alpha - self.results[1]*(int(self.file2)+d)**alpha)/((int(self.file1) + d)**alpha-(int(self.file2)+d)**alpha)
+        return (self.results[0]*(int(self.file1)+self.d)**self.alpha - self.results[1]*(int(self.file2)+self.d)**self.alpha)/((int(self.file1) + self.d)**self.alpha-(int(self.file2)+self.d)**self.alpha)
 
 

--- a/embasi/workflows/extrapolation.py
+++ b/embasi/workflows/extrapolation.py
@@ -64,6 +64,17 @@ class Extrapolation:
         self.d = d
         self.alpha = alpha
 
+    def checkInParam(self, item, default, cycle):
+        if cycle == 0:
+            app_Dict = self.projection1_param.items()
+        else:
+            app_Dict = self.projection2_param.items()
+        for key, val in app_Dict:
+            if key == item:
+                return val
+
+        return default
+
     @property
     def extrapolate(self) -> float:
         cycle: int = 0
@@ -91,7 +102,10 @@ class Extrapolation:
                 embed_mask=self.embed_mask,
                 calc_base_hl=self.calc_hl,
                 calc_base_ll=self.calc_ll,
-                mu_val=self.mu_val
+                mu_val=self.mu_val,
+                total_energy_corr= self.checkInParam("total_energy_corr","1storder", cycle),
+                localisation = self.checkInParam("localisation","SPADE", cycle),
+                projection = self.checkInParam("projection","level-shift", cycle)
             )
 
             if cycle == 0:

--- a/embasi/workflows/extrapolation.py
+++ b/embasi/workflows/extrapolation.py
@@ -1,4 +1,4 @@
-import os,sys
+import os,sys,typing
 from argparse import ArgumentError
 try:
     from embasi.embedding import ProjectionEmbedding
@@ -8,9 +8,6 @@ except ImportError:
     parent_dir2 = os.path.dirname(parent_dir)
     sys.path.append(parent_dir2)
     from embasi.embedding import ProjectionEmbedding
-from embasi.embedding import ProjectionEmbedding
-import typing
-
 
 #os.environ["ASI_LIB_PATH"] = "/home/dchen/Software/FHIaims/_build_lib/libaims.250711.scalapack.mpi.so"
 
@@ -49,7 +46,7 @@ class Extrapolation:
         Value used for the formula E(∞)
 
     """
-    def __init__(self, file1, file2, path, atom, embed_mask, calc_ll, calc_hl, asi_path,projection1_param={},projection2_param={},d=2.65,alpha=4.51):
+    def __init__(self, file1, file2, path, atom, embed_mask, calc_ll, calc_hl, asi_path, projection1_param = {} , projection2_param = {} ,d=2.65, alpha = 4.51, **kwargs):
         self.asi_path = asi_path
         os.environ["ASI_LIB_PATH"] = self.asi_path
         self.file1:str= file1
@@ -61,9 +58,7 @@ class Extrapolation:
         self.calc_hl = calc_hl
         self.mu_val: float = 1.e+6
         self.options: typing.List[str] = [file1,file2]
-        self.cleansed_objects = []
         self.results = []
-        self.energy = []
         self.projection1_param = projection1_param
         self.projection2_param = projection2_param
         self.d = d
@@ -71,7 +66,7 @@ class Extrapolation:
 
     @property
     def extrapolate(self) -> float:
-        type: int = 0
+        cycle: int = 0
         try:
             conv1 = int(self.file1)
             conv2 = int(self.file2)
@@ -99,7 +94,7 @@ class Extrapolation:
                 mu_val=self.mu_val,
             )
 
-            if type == 0:
+            if cycle == 0:
                 for key, val in self.projection1_param.items():
                     projection.parameters[key] = val
             else:
@@ -111,7 +106,7 @@ class Extrapolation:
             energy = projection.DFT_AinB_total_energy
 
             self.results.append(energy)
-            type +=1
+            cycle +=1
 
         return (self.results[0]*(int(self.file1)+self.d)**self.alpha - self.results[1]*(int(self.file2)+self.d)**self.alpha)/((int(self.file1) + self.d)**self.alpha-(int(self.file2)+self.d)**self.alpha)
 

--- a/embasi/workflows/extrapolation.py
+++ b/embasi/workflows/extrapolation.py
@@ -46,7 +46,7 @@ class Extrapolation:
         Value used for the formula E(∞)
 
     """
-    def __init__(self, file1, file2, path, atom, embed_mask, calc_ll, calc_hl, asi_path, projection1_param = {} , projection2_param = {} ,d=2.65, alpha = 4.51, **kwargs):
+    def __init__(self, file1, file2, path, atom, embed_mask, calc_ll, calc_hl, asi_path, projection1_param = {} , projection2_param = {} , d=2.65, alpha = 4.51, **kwargs):
         self.asi_path = asi_path
         os.environ["ASI_LIB_PATH"] = self.asi_path
         self.file1:str= file1
@@ -91,15 +91,15 @@ class Extrapolation:
                 embed_mask=self.embed_mask,
                 calc_base_hl=self.calc_hl,
                 calc_base_ll=self.calc_ll,
-                mu_val=self.mu_val,
+                mu_val=self.mu_val
             )
 
             if cycle == 0:
                 for key, val in self.projection1_param.items():
-                    projection.parameters[key] = val
+                    setattr(projection, key, val)
             else:
                 for key, val in self.projection2_param.items():
-                    projection.parameters[key] = val
+                    setattr(projection, key, val)
 
             projection.run()
 

--- a/embasi/workflows/extrapolation.py
+++ b/embasi/workflows/extrapolation.py
@@ -46,7 +46,7 @@ class Extrapolation:
         Value used for the formula E(∞)
 
     """
-    def __init__(self, file1, file2, path, atom, embed_mask, calc_ll, calc_hl, asi_path, projection1_param = {} , projection2_param = {} , d=2.65, alpha = 4.51, **kwargs):
+    def __init__(self, file1, file2, path, atom, embed_mask, calc_ll, calc_hl, asi_path, projection1_param = {} , projection2_param = {} , d=2.65, alpha = 4.51):
         self.asi_path = asi_path
         os.environ["ASI_LIB_PATH"] = self.asi_path
         self.file1:str= file1

--- a/embasi/workflows/extrapolation.py
+++ b/embasi/workflows/extrapolation.py
@@ -14,6 +14,11 @@ except ImportError:
 class Extrapolation:
     """
 
+    Provides an estimated value based on the assumption that the
+    existing trend would continue. Allows us to predict energy at
+    the CBS Limit by using results from smaller basis sets, while
+    maintaining a high degree of accuracy as well as a more efficient
+    method which requires less computing power as well as less time.
 
     Parameters
     ----------

--- a/tests/FHI-aims/projection_embedding/serial/QM_localisation/test_qmloc.py
+++ b/tests/FHI-aims/projection_embedding/serial/QM_localisation/test_qmloc.py
@@ -6,7 +6,11 @@ from pytest_regressions.num_regression import NumericRegressionFixture
 
 sys.path.append(os.getcwd()+"/../../../")
 print(sys.path)
-from fhiaims_meoh_test_generator import FHIaims_projection_embedding_test
+try:
+    from fhiaims_meoh_test_generator import FHIaims_projection_embedding_test
+except ImportError:
+    sys.path.insert(1,"/home/dchen/Downloads/DChen_EmbASI/")
+    from tests.fhiaims_meoh_test_generator import FHIaims_projection_embedding_test
 
 def test_qmcode_localisation_serial(num_regression: NumericRegressionFixture, tmp_path):
 

--- a/tests/FHI-aims/projection_embedding/serial/SPADE_localisation/test_spade.py
+++ b/tests/FHI-aims/projection_embedding/serial/SPADE_localisation/test_spade.py
@@ -6,7 +6,11 @@ from pytest_regressions.num_regression import NumericRegressionFixture
 
 sys.path.append(os.getcwd()+"/../../../")
 print(sys.path)
-from fhiaims_meoh_test_generator import FHIaims_projection_embedding_test
+try:
+    from fhiaims_meoh_test_generator import FHIaims_projection_embedding_test
+except ImportError:
+    sys.path.insert(1,"/home/dchen/Downloads/DChen_EmbASI/")
+    from tests.fhiaims_meoh_test_generator import FHIaims_projection_embedding_test
 
 def test_spade_localisation_serial(num_regression: NumericRegressionFixture, tmp_path):
 

--- a/tests/FHI-aims/projection_embedding/serial/level_shift_projection/test_level-shift.py
+++ b/tests/FHI-aims/projection_embedding/serial/level_shift_projection/test_level-shift.py
@@ -6,7 +6,6 @@ from pytest_regressions.num_regression import NumericRegressionFixture
 
 sys.path.append(os.getcwd()+"/../../../")
 print(sys.path)
-from fhiaims_meoh_test_generator import FHIaims_projection_embedding_test
 
 def test_level_shift_projection_serial(num_regression: NumericRegressionFixture, tmp_path):
 

--- a/tests/fhiaims_extrapolate_test_generator.py
+++ b/tests/fhiaims_extrapolate_test_generator.py
@@ -1,0 +1,101 @@
+
+from ase.data.s22 import s22, s26, create_s22_system
+import os,sys
+from ase.calculators.aims import Aims, AimsProfile
+
+try:
+    from embasi.workflows.extrapolation import Extrapolation
+except ImportError:
+    sys.path.insert(1,"/home/dchen/Downloads/DChen_EmbASI/")
+
+    from embasi.workflows.extrapolation import Extrapolation
+
+class FHIaims_projection_embedding_extrpolate_test():
+    def __init__(self, localisation="SPADE", projection="huzinaga", parallel=False, gc=False,
+                 calc_ll_param_dict={}, calc_hl_param_dict={}, test_dir=None, basis_dir="defaults_2020/light"):
+        # Set-up calculator parameters (similar to FHIaims Calculator for
+        # ASE) for low-level and high-level calculations. Below are the
+        # absolute minimum parameters required for normal operation.
+
+        self.calc_ll = Aims(
+            xc='PBE',
+            profile=AimsProfile(command="asi-doesnt-need-command"),
+            KS_method="parallel",
+            RI_method="LVL",
+            collect_eigenvectors=True,
+            density_update_method='density_matrix',  # for DM export
+            atomic_solver_xc="PBE",
+            compute_kinetic=True,
+            override_initial_charge_check=True,
+        )
+
+        for key, val in calc_ll_param_dict.items():
+            self.calculator_ll.parameters[key] = val
+
+        self.calc_hl = Aims(
+            xc='PBE',
+            profile=AimsProfile(command="asi-doesnt-need-command"),
+            KS_method="parallel",
+            RI_method="LVL",
+            collect_eigenvectors=True,
+            density_update_method='density_matrix',  # for DM export
+            atomic_solver_xc="PBE",
+            compute_kinetic=True,
+            override_initial_charge_check=True,
+        )
+        for key, val in calc_hl_param_dict.items():
+            self.calculator_hl.parameters[key] = val
+        self.localisation = localisation
+        self.projection = projection
+        self.parallel = False
+        self.gc = False
+        self.test_dir = test_dir
+        #os.environ["AIMS_SPECIES_DIR"] = os.environ["AIMS_ROOT_DIR"] + "/species_defaults/" + basis_dir
+        self.energy = None
+        self.energy2 = None
+        self.diff_energy = None
+
+    def run_test(self):
+
+        # Creates a S22 system s26[22], with 22 being the ID from ASE
+        methanol_dimer = create_s22_system(s26[22])
+        energy = Extrapolation(
+            file1="3",
+            file2="2",
+            path="/home/dchen/Software/FHIaims/species_defaults/NAO-VCC-nZ/NAO-VCC-",
+            asi_path="/home/dchen/Software/FHIaims/_build_lib/libaims.250711.scalapack.mpi.so",
+            atom= methanol_dimer,
+            embed_mask=[2, 1, 2, 2, 2, 1, 2, 1, 2, 2, 2, 1],
+            calc_ll=self.calc_ll,
+            calc_hl=self.calc_hl,
+        )
+
+        energy2 = Extrapolation(
+            file1="3",
+            file2="2",
+            path="/home/dchen/Software/FHIaims/species_defaults/NAO-VCC-nZ/NAO-VCC-",
+            asi_path="/home/dchen/Software/FHIaims/_build_lib/libaims.250711.scalapack.mpi.so",
+            atom=methanol_dimer[:6],
+            embed_mask=[2,1,2,2,2,1],
+            calc_ll=self.calc_ll,
+            calc_hl=self.calc_hl,
+        )
+
+        energy = energy.extrapolate  # Finds the monomer energy of the methanol
+        self.energy = energy  # Stores the energy
+
+        energy2 = energy2.extrapolate  # FInds the monomer energy of the methanol dimer
+        self.energy2 = energy2
+
+        self.diff_energy = energy - 2 * energy2 # Calculates the dissociation energy: diss_energy = energy2 - 2(energy1)
+
+    def output_ref_values(self):
+        return {
+            "Methanol Dimer": self.energy2,
+            "Methanol": self.energy,
+            "Dissociation Energy": self.diff_energy,
+        }
+
+
+
+

--- a/tests/fhiaims_meoh_test_generator.py
+++ b/tests/fhiaims_meoh_test_generator.py
@@ -24,7 +24,7 @@ class FHIaims_projection_embedding_test():
                        )
         
         for key, val in calc_ll_param_dict.items():
-            self.calculator_ll.parameters[key]=val
+            self.calc_ll.parameters[key]=val
 
         self.calc_hl = Aims(xc='PBE', profile=AimsProfile(command="asi-doesnt-need-command"),
                        KS_method="parallel",
@@ -37,7 +37,7 @@ class FHIaims_projection_embedding_test():
                        )
 
         for key, val in calc_hl_param_dict.items():
-            self.calculator_hl.parameters[key]=val
+            self.calc_hl.parameters[key]=val
 
         self.localisation = localisation
         self.projection = projection


### PR DESCRIPTION
- Implemented a class within workflows to allow you to calculate the extrapolation value of basis sets
- Created an example in examples/FHIaims/basic_extrapolation of how it works
- Also implemented a test in tests/FHI-aims/projection_embedding/serial/extrapolate/test_extrapolate


Extrapolation is the process of estimating a value based on the assumption that the existing trend will continue or is consistent.  In our case, it means that we are able to predict the energy at the Complete Basis Set (CBS) limit by using the results from the smaller basis sets. The usage of smaller basis sets allows us to speed up the process of getting calculations whilst still being precise to a high standard. The larger the basis set, the more computational cost it requires, which means that extrapolation helps to reduce the computational power required as well as the time taken whilst maintaining a high precision.
