### PR TITLE
Remove FHI-aims Specific Calculator Directives

### DIFF
--- a/docs/dev_guide.rst
+++ b/docs/dev_guide.rst
@@ -88,13 +88,14 @@ this keyword are:
 Python Interface Modifications
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-**In progress**
-
-As calculation input file generation and output file parsing is performed with `ASE <https://ase-lib.org/>__, some modification to the Pythonic wrapper may be needed to support the specification of ghost basis functions. As this syntax is different for each calculator object, ``embasi/qmcode_input_directives.py`` will need to be modified to provide the correct syntax for:
+Input file generation and output file parsing is performed with `ASE <https://ase-lib.org/>__. The syntax for some input parameters, including total charge and specifying ghost sites, differs between each calculator. To support these inputs, EmbASI requires some modification (``embasi/qmcode_input_directives.py``). This module contains the abstract ``ase_calc_parameter_setter``, which supports the following workflows for different ASE calculators:
 
    1. Setting the number of SCF cycles to 0.
    2. Creating an input file with ghost basis functions.
    3. Keyword modifications for calling post-HF calculations.
+   4. Setting keywqords for setting the ScaLAPACK block size (Parallel only).
+
+To support a new calculator, a concrete implementation of ``ase_calc_parameter_setter`` must be provided, and the name of your calculator added to ``implemented_calculators``. Please refer to the FHI-aims implementation (``Aims_param_setter``) for direction.
 
 References
 ~~~~~~~~~~

--- a/docs/dev_guide.rst
+++ b/docs/dev_guide.rst
@@ -58,8 +58,8 @@ matrices are output to the EmbASI wrapper:
 To integrate these routines within your workflow, the following routines
 from the ``qm_embedding`` template should be added in the following parts of your code:
    1. ``export_overlap``: after the construction of the overlap matrix.
-   2. ``export_allH``: after the final interation of the SCF cycle.
-   3. ``export_densmat``: after the final interation of the SCF cycle.
+   2. ``export_allH``: after the final iteration of the SCF cycle.
+   3. ``export_densmat``: after the final iteration of the SCF cycle.
 
 Expected Matrix Imports
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -88,12 +88,12 @@ this keyword are:
 Python Interface Modifications
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Input file generation and output file parsing is performed with `ASE <https://ase-lib.org/>__. The syntax for some input parameters, including total charge and specifying ghost sites, differs between each calculator. To support these inputs, EmbASI requires some modification (``embasi/qmcode_input_directives.py``). This module contains the abstract ``ase_calc_parameter_setter``, which supports the following workflows for different ASE calculators:
+Input file generation and output file parsing is performed with `ASE <https://ase-lib.org/>__. The syntax for some input parameters, including the total charge and specification of ghost sites, differ between each calculator. EmbASI requires the correct specification of these input in the ``qmcode_input_directives`` module. This module contains the abstract ``ase_calc_parameter_setter``, which supports the following inputs for different ASE calculators:
 
-   1. Setting the number of SCF cycles to 0.
+   1. Setting the correct syntax for a total energy only calculation.
    2. Creating an input file with ghost basis functions.
    3. Keyword modifications for calling post-HF calculations.
-   4. Setting keywords the ScaLAPACK block size (Parallel only).
+   4. Setting the ScaLAPACK block size (Parallel only).
 
 To support a new calculator, a concrete implementation of ``ase_calc_parameter_setter`` must be provided, and the name of your calculator added to ``implemented_calculators``. Please refer to the FHI-aims implementation (``Aims_param_setter``) for direction.
 

--- a/docs/dev_guide.rst
+++ b/docs/dev_guide.rst
@@ -93,7 +93,7 @@ Input file generation and output file parsing is performed with `ASE <https://as
    1. Setting the number of SCF cycles to 0.
    2. Creating an input file with ghost basis functions.
    3. Keyword modifications for calling post-HF calculations.
-   4. Setting keywqords for setting the ScaLAPACK block size (Parallel only).
+   4. Setting keywords the ScaLAPACK block size (Parallel only).
 
 To support a new calculator, a concrete implementation of ``ase_calc_parameter_setter`` must be provided, and the name of your calculator added to ``implemented_calculators``. Please refer to the FHI-aims implementation (``Aims_param_setter``) for direction.
 

--- a/docs/dev_guide.rst
+++ b/docs/dev_guide.rst
@@ -6,15 +6,23 @@ Introduction
 ~~~~~~~~~~~~
 
 EmbASI is designed as a minimal workflow for abstracting the tasks associated
-with embedding to the Pythonic wrapper. The modification to the host codebase
-should be small, but some familiarity with your codebase is desirable to
-implement the required control flow mechanisms.
+with embedding to a Pythonic wrapper. The modification to the host codebase
+should be small, but some routines for exporting and importing the correct
+data structures will need to be integrated into your core SCF loop. The placement
+of these routines should be fairly general, but familiarity with your codebase
+is desirable to implement the required control flow mechanisms.
 
 Where possible, we have provided template routines in ``<EmbASI_ROOT>/templates/fortran/qm_embedding.f90``
 which wrap around the expected import and export routines for each
 matrix quantity.
 
+Before implementing EmbASI into your QM code, you will require the following
+features in your codebase:
+   1. An interface to the ASI API, see: :ref:`section-asi-api`.
+   2. The ability to output the core Hamiltonian (or the one-electron Hamiltonian) and the two-electron Hamiltonian (electrostatic and exchange-correlation contributions).
+   3. The ability to set certain atomic sites as ghost atoms.
 
+.. _section-asi-api:
 Atomic Simulation Interface (ASI) API
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/embasi/atoms_embedding_asi.py
+++ b/embasi/atoms_embedding_asi.py
@@ -1,11 +1,14 @@
 from asi4py.asecalc import ASI_ASE_calculator
-from embasi.parallel_utils import root_print, mpi_bcast_matrix_storage, \
-    mpi_bcast_integer
 import scalapack4py.npscal.math_utils.operations as op
 import numpy as np
 import time
 from mpi4py import MPI
-from .ks_array import SpinKpointArray
+
+from embasi.parallel_utils import root_print, mpi_bcast_matrix_storage, \
+    mpi_bcast_integer
+from embasi.ks_array import SpinKpointArray
+from embasi.qmcode_input_directives import ase_calc_parameter_setter
+
 from scalapack4py.npscal import NPScal
 from typing import overload, Union
 from functools import singledispatch, singledispatchmethod
@@ -73,7 +76,7 @@ class AtomsEmbed():
             self.parallel = True
             self.blacs_ctxt_tag = ctxt_tag
             self.blacs_descr_tag = descr_tag
-            
+
         if isinstance(embed_mask, int):
             # We hope the user knows what they are doing and
             # their atoms object is ordered accordingly.
@@ -90,6 +93,7 @@ class AtomsEmbed():
             self.reorder_atoms_from_embed_mask()
             self.atoms.info['embedding_mask'] = self.embed_mask
 
+        self.param_setter = ase_calc_parameter_setter(initial_calc)
         self.initial_calc = initial_calc
 
         self.truncate = False
@@ -114,7 +118,7 @@ class AtomsEmbed():
         calc = self.runtime_calc
 
         if self.truncate:
-            self.ghost_list_calc = [ 
+            self.ghost_list_calc = [
                 ghst for (idx, ghst) in enumerate(self.ghost_list)
                 if idx in self.basis_info.active_atoms ]
         else:
@@ -134,19 +138,23 @@ class AtomsEmbed():
             total_charge = self.fragment_total_charge
         else:
             total_charge = 0.
-        
-        calc.parameters['charge'] = -float(total_charge)
+
+        # Set the calculator to accept the total charge for the given fragment
+        calc = self.param_setter.set_qm_total_charge(calc, -float(total_charge))
+        calc = self.param_setter.set_ghost_atoms(calc, self.atoms, self.ghost_list_calc)
 
         # Ensure the Aims template shares the input parameters of the calculator object
-        calc.parameters["ghosts"] = self.ghost_list_calc
         calc.template.parameters = calc.parameters
 
         calc.write_inputfiles(asi.atoms, properties=['energy'])
 
-        if self.embed_mask is not None and self.insert_embedding_region:
-            self._insert_embedding_region_aims()
+        # Nasty cludge for adding certain, non-ASE supported keywords
+        # to the FHI-aims calculator.
+        if self.param_setter.asi_flavour == 1:
+            if self.embed_mask is not None and self.insert_embedding_region:
+                self._insert_embedding_region_aims()
 
-        self._insert_custom_aims_controlin()
+            self._insert_custom_aims_controlin()
 
     def reorder_atoms_from_embed_mask(self):
         """ Re-orders atoms to push those in embedding region 1 to the beginning
@@ -165,13 +173,13 @@ class AtomsEmbed():
         self.atoms = self.atoms[idx_list]
 
         if "ghosts" in self.atoms.info.keys():
-            self.atoms.info["ghosts"] = [ 
+            self.atoms.info["ghosts"] = [
                 self.atoms.info["ghosts"][idx] for idx in idx_list ]
 
     def _insert_embedding_region_aims(self):
         """Places embedding regions in input file
 
-        This functionality would require ASE support of the 
+        This functionality would require ASE support of the
         qm_embedding_region, so instead we handle this in a rather ad hoc
         way and inserts the qm_embedding_region variable for each atom
         in the geometry.in file.
@@ -237,7 +245,7 @@ class AtomsEmbed():
                 new_spinks_mat[(ispin,ikpoint)] = self.full_mat_to_truncated(spinks_mat[ispin,ikpoint])
 
         return SpinKpointArray(new_spinks_mat, spinks_mat.n_spins, spinks_mat.n_kpoints)
-    
+
     @full_mat_to_truncated.register
     def _(self, full_mat: Union[np.ndarray | NPScal]):
         """Converts a matrix quantity from a full to a truncated basis
@@ -289,7 +297,7 @@ class AtomsEmbed():
 
             trunc_mat_row = NPScal(ctxt_tag=self.blacs_ctxt_tag, descr_tag=f"{self.blacs_descr_tag}_temp_rectangle_f2t", lib=lib,
                                    gl_m=trunc_nbasis, gl_n=full_nbasis, dmb=mb, dnb=nb)
-            
+
             trunc_mat = NPScal(ctxt_tag=self.blacs_ctxt_tag, descr_tag=self.blacs_descr_tag, lib=lib,
                                gl_m=trunc_nbasis, gl_n=trunc_nbasis, dmb=mb, dnb=nb)
 
@@ -315,7 +323,7 @@ class AtomsEmbed():
 
             full_row_min = full_basis_min_idx[atom_min] + 1
             full_row_max = full_basis_max_idx[atom_max]
-            
+
             new_m = full_row_max - full_row_min + 1
             new_n = full_nbasis
 
@@ -356,7 +364,7 @@ class AtomsEmbed():
     @singledispatchmethod
     def truncated_mat_to_full(self, trunc_mat):
         raise Exception("Not implemented.")
-    
+
     @truncated_mat_to_full.register
     def _(self, spinks_mat: SpinKpointArray):
         """A wrapper for truncated_mat_to_full with spinks_mat"""
@@ -452,7 +460,7 @@ class AtomsEmbed():
                                       full_mat_row.loc_array, full_row_min, 1, full_mat_row.descr, trunc_mat.ctxt.ctxt)
             else:
                 full_mat_row[full_row_min-1:full_row_max,:] = trunc_mat[trunc_row_min-1:trunc_row_max,:]
-                
+
         for block1 in continous_at_blocks:
             if len(block1)==1:
                 atom_min = block1[0]
@@ -523,7 +531,9 @@ class AtomsEmbed():
         self.density_matrix_in = dm_in
 
         self.runtime_calc = deepcopy(self.initial_calc)
-        self.runtime_calc.parameters['qm_embedding_calc'] = 1
+
+        self.runtime_calc = \
+            self.param_setter.set_full_scf_calc(self.runtime_calc)
 
         self.run()
 
@@ -537,9 +547,7 @@ class AtomsEmbed():
         self.density_matrix_in = dm_in
 
         self.runtime_calc = deepcopy(self.initial_calc)
-        self.runtime_calc.parameters['qm_embedding_calc'] = 2
-        self.runtime_calc.parameters['sc_iter_limit'] = 0
-        self.runtime_calc.parameters['charge_mix_param'] = 0.
+        self.runtime_calc = self.param_setter.set_noscf_calc_params(self.runtime_calc)
 
         time_s = time.time()
         self.run(ev_corr_scf=True, close_calc=close_calc)
@@ -556,7 +564,8 @@ class AtomsEmbed():
         from copy import copy, deepcopy
 
         self.runtime_calc = deepcopy(self.initial_calc)
-        self.runtime_calc.parameters['qm_embedding_calc'] = 3
+        self.runtime_calc = \
+            self.param_setter.set_full_scf_embed_calc(self.runtime_calc)
 
         # TODO: REMOVE FHI-AIMS SPECIFIC DIRECTIVES - LEAVE WF CALCULATION TO POSTPROC
         #if "total_energy_method" in self.runtime_calc.parameters:
@@ -594,7 +603,6 @@ class AtomsEmbed():
         import time
         from embasi.roothan_hall_eigensolver_scalapack import hamiltonian_eigensolv_parallel
         from embasi.roothan_hall_eigensolver import hamiltonian_eigensolv
-                
 
         def calculate_abs_trunc_huzinaga_projector(atomsembed):
 
@@ -718,7 +726,7 @@ class AtomsEmbed():
         Driver routine which executes the QM code and controls which
         callbacks are registered, which matrix quantities are exported,
         and initialises relevant properties from previous calculations.
-        
+
         Parameters
         ----------
         ev_corr_scf: bool
@@ -735,11 +743,13 @@ class AtomsEmbed():
                                                         ham_saving_and_huzinaga_callback, \
                                                         ovlp_saving_callback, \
                                                         matrix_loading_callback
+        from embasi.roothan_hall_eigensolver_scalapack import hamiltonian_eigensolv_parallel
+        from embasi.roothan_hall_eigensolver import hamiltonian_eigensolv
 
         root_print(f'Calculation {self.outdir}...')
 
         start_time = time.time()
-        
+
         if self.truncate and len(self.atoms) != self.basis_info.trunc_natoms:
             self.atoms = self.atoms[self.basis_info.active_atoms]
 
@@ -783,14 +793,14 @@ class AtomsEmbed():
         self.atoms.calc.asi.dm_storage = {}
         self.atoms.calc.asi.dm_calc_cnt = {}
         self.atoms.calc.asi.dm_count = 0
-        self.atoms.calc.asi.register_dm_callback(dm_saving_callback, 
-                                                 (self.atoms.calc.asi, 
-                                                  self.atoms.calc.asi.dm_storage, 
+        self.atoms.calc.asi.register_dm_callback(dm_saving_callback,
+                                                 (self.atoms.calc.asi,
+                                                  self.atoms.calc.asi.dm_storage,
                                                   self.atoms.calc.asi.dm_calc_cnt,
                                                   self.blacs_ctxt_tag,
                                                   self.blacs_descr_tag,
                                                   'DM calc'))
-        
+
         self.atoms.calc.asi.ham_storage = {}
         self.atoms.calc.asi.ham_calc_cnt = {}
         self.atoms.calc.asi.ham_count = 0
@@ -806,7 +816,7 @@ class AtomsEmbed():
                                                                self.blacs_descr_tag,
                                                                'Ham calc'))
         else:
-            self.atoms.calc.asi.register_hamiltonian_callback(ham_saving_callback, 
+            self.atoms.calc.asi.register_hamiltonian_callback(ham_saving_callback,
                                                               (self.atoms.calc.asi,
                                                                self.atoms.calc.asi.ham_storage,
                                                                self.atoms.calc.asi.ham_calc_cnt,
@@ -824,7 +834,7 @@ class AtomsEmbed():
                                                  'DM init'))
 
         # Make sure we don't run with an already stored embedding potential unless
-        # It is actually called for. 
+        # It is actually called for.
         if ((self.fock_embedding_matrix is not None) and (emb_pot_scf)):
             if self.truncate:
                 mat_in = self.fock_embedding_matrix_trunc
@@ -898,6 +908,7 @@ class AtomsEmbed():
         self._ham_2ee = SpinKpointArray(self.atoms.calc.asi.ham_storage[1], self.n_spins, self.n_kpoints)
         self._ham_tot = SpinKpointArray(self.atoms.calc.asi.ham_storage[2], self.n_spins, self.n_kpoints)
         self._ovlp = SpinKpointArray(self.atoms.calc.asi.overlap_storage, self.n_spins, self.n_kpoints)
+
         # THIS IS CODE BREAKING FOR QM CODE LOCALISATION - I WILL NEED A FIX TO RESTORE
         if (1 in self.atoms.calc.asi.dm_storage.keys()):
             self._dm = []
@@ -905,7 +916,7 @@ class AtomsEmbed():
             self._dm.append(SpinKpointArray(self.atoms.calc.asi.dm_storage[1], self.n_spins, self.n_kpoints))
         else:
             self._dm = SpinKpointArray(self.atoms.calc.asi.dm_storage[0], self.n_spins, self.n_kpoints)
-                
+
         if close_calc:
             self.atoms.calc.asi.close()
 
@@ -916,50 +927,117 @@ class AtomsEmbed():
 
         self.extract_results()
 
-        # Within the embedding workflow, we often want to calculate the total 
-        # energy for a given density matrix without performing any SCF steps. 
-        # Often, this includes using an input electron density constructed from 
-        # a localised set of MOs for a fragment of a supermolecule. This 
+        # Within the embedding workflow, we often want to calculate the total
+        # energy for a given density matrix without performing any SCF steps.
+        # Often, this includes using an input electron density constructed from
+        # a localised set of MOs for a fragment of a supermolecule. This
         # density will be far from the ground-state density for the fragment,
-        # meaning the output eigenvalues significantly deviate from those of a 
+        # meaning the output eigenvalues significantly deviate from those of a
         # fully converged density.
         #
         # As the vast majority of DFT codes with the KS-eigenvalues to determine
-        # the total energy, the total energies due to the eigenvalues do not 
-        # formally reflect the density matrix of the initial input for 
+        # the total energy, the total energies due to the eigenvalues do not
+        # formally reflect the density matrix of the initial input for
         # iteration, n=0:
         #
         #    \gamma^{n+1} * H^{total}[\gamma^{n}] \= \gamma^{n} * H^{total}[\gamma^{n}],
         #
-        # For TE-only calculations, we do not care about the SCF process - we 
-        # are using the DFT code to integrate XC and electrostatic energies. As 
+        # For TE-only calculations, we do not care about the SCF process - we
+        # are using the DFT code to integrate XC and electrostatic energies. As
         # such, we 'correct' the eigenvalue portion of the total energy to reflect
-        # the interaction of the input density matrix, as opposed to the first 
+        # the interaction of the input density matrix, as opposed to the first
         # set of KS-eigenvectors resulting from the DFT code.
-        if ev_corr_scf:
-            if self.truncate:
-                self.ev_corr_energy = \
-                    27.211384500 * \
-                    (self.density_matrix_in @ self.full_mat_to_truncated(self.hamiltonian_total)).trace()
-            else:
-                self.ev_corr_energy = \
-                    27.211384500 * (self.density_matrix_in @ self.hamiltonian_total).trace()
+        if ev_corr_scf or ev_corr_scf_final_density:
 
-            self.ev_corr_total_energy = \
-                self.total_energy - self.ev_sum + self.ev_corr_energy
+            # To make sure we are holding the correct sum of eigenvalues,
+            # we conduct one final eigensolution, rather than grepping (the
+            # solution for FHI-aims).
+            if not hasattr(self, "ev_sum"):
+                self.ev_sum = self.ev_solve_and_sum_evs(emb_pot_scf)
 
-        if ev_corr_scf_final_density:
-            if self.truncate:
-                self.ev_corr_energy = \
-                    27.211384500 * (self.full_mat_to_truncated(self.density_matrices_out) @ 
-                                self.full_mat_to_truncated(self.hamiltonian_total)).trace()
-            else:
-                self.ev_corr_energy = \
-                    27.211384500 * (self.density_matrices_out @ self.hamiltonian_total).trace()
+            if ev_corr_scf:
+                if self.truncate:
+                    self.ev_corr_energy = \
+                        27.211384500 * \
+                        (self.density_matrix_in @ self.full_mat_to_truncated(self.hamiltonian_total)).trace()
+                else:
+                    self.ev_corr_energy = \
+                        27.211384500 * (self.density_matrix_in @ self.hamiltonian_total).trace()
 
                 self.ev_corr_total_energy = \
                     self.total_energy - self.ev_sum + self.ev_corr_energy
-                
+
+            if ev_corr_scf_final_density:
+                if self.truncate:
+                    self.ev_corr_energy = \
+                        27.211384500 * (self.full_mat_to_truncated(self.density_matrices_out) @
+                                        self.full_mat_to_truncated(self.hamiltonian_total)).trace()
+                else:
+                    self.ev_corr_energy = \
+                        27.211384500 * (self.density_matrices_out @ self.hamiltonian_total).trace()
+
+                self.ev_corr_total_energy = \
+                    self.total_energy - self.ev_sum + self.ev_corr_energy
+
+
+    def ev_solve_and_sum_evs(self, emb_pot_scf):
+        """Solves the KS eigenvalue equation and sums the eigenvalues
+
+        This routine returns the sum of KS eigenvalues with the
+        Hamiltonian output by the KS code. This avoids having specific
+        file parsing for each code, but adds extra expense. TODO: Add
+        eigenvalue sum to the ASI API.
+        """
+        from embasi.roothan_hall_eigensolver_scalapack import hamiltonian_eigensolv_parallel
+        from embasi.roothan_hall_eigensolver import hamiltonian_eigensolv
+
+        if self.truncate:
+            post_calc_ham = self.full_mat_to_truncated(self.hamiltonian_total)
+            ovlp = self.full_mat_to_truncated(self.overlap)
+        else:
+            post_calc_ham = self.hamiltonian_total.copy()
+            ovlp = self.overlap
+
+        if ((self.fock_embedding_matrix is not None) and (emb_pot_scf)):
+            if hasattr(self.atoms.calc.asi, "huzinaga_eq"):
+                for spin in range(self.n_kpoints):
+                    for kpt in range(self.n_kpoints):
+                        post_calc_ham[spin, kpt] = post_calc_ham[spin, kpt] + \
+                            self.atoms.calc.asi.huzinaga_eq[(spin, kpt)]
+            else:
+                if self.truncate:
+                    post_calc_ham[spin, kpt] = post_calc_ham + self.fock_embedding_matrix_trunc
+                else:
+                    post_calc_ham[spin, kpt] = post_calc_ham + self.fock_embedding_matrix
+
+        nelecs = self.input_fragment_nelectrons
+        if self.parallel:
+            evals, evecs, occ_mat = hamiltonian_eigensolv_parallel(post_calc_ham, \
+                                                                   ovlp, \
+                                                                   nelecs, \
+                                                                   nspins=self.n_spins, \
+                                                                   nkpts=self.n_kpoints, \
+                                                                   return_orthog=False, \
+                                                                   basis_illcond_thresh=1e-5)
+        else:
+            evals, evecs, occ_mat = hamiltonian_eigensolv(post_calc_ham, \
+                                                          ovlp, \
+                                                          nelecs, \
+                                                          nspins=self.n_spins, \
+                                                          nkpts=self.n_kpoints, \
+                                                          basis_illcond_thresh=1e-5)
+
+        ev_sum = 0.
+        for spin in range(evals.n_spins):
+            for kpt in range(evals.n_kpoints):
+                occ_mask = occ_mat[spin, kpt] > 0.
+                ev_sum += np.sum(evals[spin, kpt][occ_mask] * \
+                                 occ_mat[spin, kpt][occ_mask]) * \
+                                 27.211384500
+
+        return ev_sum
+
+
     def close_calculator(self):
         self.atoms.calc.asi.close()
 
@@ -973,7 +1051,7 @@ class AtomsEmbed():
         self.density_matrix_in = None
         self.fock_embedding_matrix = None
         gc.collect()
-            
+
     @property
     def hamiltonian_total(self):
         return self._ham_tot
@@ -1165,7 +1243,6 @@ class AtomsEmbed():
     @property
     def basis_info(self):
         """Basisinfo object defining indices of basis elements
-        
         """
         return self._basis_info
 
@@ -1175,7 +1252,7 @@ class AtomsEmbed():
 
     @property
     def free_atom_nelectrons(self):
-        
+
         tot_nelec = np.sum(self.atoms.numbers)
         ghost_nelec = np.sum(self.atoms.numbers[self.ghost_list_calc])
 

--- a/embasi/embedding.py
+++ b/embasi/embedding.py
@@ -1,6 +1,7 @@
 # ~ Overall Embedding object
 from abc import ABC, abstractmethod
 from embasi.parallel_utils import root_print
+from embasi.qmcode_input_directives import ase_calc_parameter_setter
 import scalapack4py.npscal.math_utils.operations as op
 import copy
 import time
@@ -42,6 +43,9 @@ class EmbeddingBase(ABC):
         self.calculator_ll = calc_base_ll
         self.calculator_hl = calc_base_hl
         self.run_dir=run_dir
+
+        self.param_setter_ll = ase_calc_parameter_setter(self.calculator_ll)
+        self.param_setter_hl = ase_calc_parameter_setter(self.calculator_hl)
 
         try:
             os.makedirs(self.run_dir, exist_ok=True)
@@ -96,19 +100,19 @@ class EmbeddingBase(ABC):
         """Lists atomic centers significant charge for a given density matrix
 
         Returns a list of corresponding atoms for which the total contribution 
-        of an atoms constituent basis functions to the total charge of subsystem 
+        of an atoms constituent basis functions to the total charge of subsystem
         A, q^{A}:
 
                q^{A}_{/mu, /nu} = /gamma^{A}_{/mu, /nu} S_{/mu, /nu}
 
         exceeds the threshold, thresh:
 
-                      thresh < q_{/mu, /nu} 
+                      thresh < q_{/mu, /nu}
 
         This is unfortunately just Mulliken analysis. Future work could use
         more sophisticated charge techniques, but this would require
         volumetric charge data.
-        
+
         Parameters
         ----------
         atomsembed: AtomsEmbed
@@ -116,7 +120,7 @@ class EmbeddingBase(ABC):
         densmat: np.ndarray
             Corresponding density matrix to AtomsEmbed
         thresh: float
-            Mulliken charge threshold for 
+            Mulliken charge threshold for assigning an atom's basis funciton to a region
         Returns
         -------
         active_atom_mask: bool list
@@ -144,7 +148,7 @@ class EmbeddingBase(ABC):
         """Sets default BasisInfo objects for each embedding layer
 
         Necessary to maintain consistency in values needed for matrix truncation
-        /expansion between the AtomsEmbed objects (eg., self.basis_atoms, 
+        /expansion between the AtomsEmbed objects (eg., self.basis_atoms,
         self.n_atoms). Failure to do so leads to unexpected behaviour.
 
         Parameters
@@ -179,7 +183,7 @@ class EmbeddingBase(ABC):
         """Sets default BasisInfo objects for each embedding layer
 
         Necessary to maintain consistency in values needed for matrix truncation
-        /expansion between the AtomsEmbed objects (eg., self.basis_atoms, 
+        /expansion between the AtomsEmbed objects (eg., self.basis_atoms,
         self.n_atoms). Failure to do so leads to unexpected behaviour.
 
         Parameters
@@ -197,22 +201,22 @@ class EmbeddingBase(ABC):
         """
         from embasi.basis_info import Basis_info
 
-        # Establish mapping corresponding to each new atom from the 
+        # Establish mapping corresponding to each new atom from the
         # truncated matrix
-        active_atoms = np.array([ idx for idx, maskval 
-                                  in enumerate(active_atom_mask) 
+        active_atoms = np.array([ idx for idx, maskval
+                                  in enumerate(active_atom_mask)
                                   if (maskval or atomsembed.embed_mask[idx] == layer) ])
 
-        hl_atoms = np.array([ idx for idx, maskval 
-                                  in enumerate(active_atom_mask) 
+        hl_atoms = np.array([ idx for idx, maskval
+                                  in enumerate(active_atom_mask)
                                   if (atomsembed.embed_mask[idx] == 1) ])
-        env_atoms = np.array([ idx for idx, maskval 
-                                  in enumerate(active_atom_mask) 
+        env_atoms = np.array([ idx for idx, maskval
+                                  in enumerate(active_atom_mask)
                                   if (maskval and (not atomsembed.embed_mask[idx] == layer)) ])
 
         # Remove non-active atoms from basis_atoms to form a truncated
         # analogue
-        trunc_basis_atoms = np.array([atom for atom in atomsembed.basis_atoms 
+        trunc_basis_atoms = np.array([atom for atom in atomsembed.basis_atoms
                                       if atom in active_atoms])
 
         # Count number of basis functions included in truncation calculations
@@ -220,7 +224,7 @@ class EmbeddingBase(ABC):
         for atom in atomsembed.basis_atoms:
             if active_atom_mask[atom]:
                 new_nbasis +=1
-        
+
         root_print(f" " )
         root_print( f" ----------- Performing Truncation --------- " )
         root_print(f" ")
@@ -248,7 +252,7 @@ class EmbeddingBase(ABC):
 
     def calc_subsys_pop(self, overlap_matrix, density_matrix):
         """Calculated number of electrons in a subsystem
-        
+
         Calculates the overall electron population of a given subsystem
         through the following relation:
                         P_{pop} = tr[S^{AB}/gamma]
@@ -257,14 +261,14 @@ class EmbeddingBase(ABC):
 
         Parameters
         ----------
-        overlap_matrix: np.ndarray 
+        overlap_matrix: np.ndarray
             Supersystem overlap matrix in AO basis.
-        density_matrix: np.ndarray 
+        density_matrix: np.ndarray
             Subsystem density matrix in AO basis,
 
         Returns
         -------
-        population: float 
+        population: float
             Overall electronic population of subsystem
 
         """
@@ -273,7 +277,7 @@ class EmbeddingBase(ABC):
         population = (overlap_matrix @ density_matrix).trace()
 
         return population
-    
+
     @abstractmethod
     def run(self):
         pass
@@ -308,6 +312,10 @@ class EmbeddingBase(ABC):
         for scf in val:
             self._scf_methods.append(scf)
 
+
+
+
+
 class StandardDFT(EmbeddingBase):
 
     def __init__(self, atoms, calc_base_ll, embed_mask=None, calc_base_hl=None, run_dir="./EmbASI_calc"):
@@ -323,7 +331,7 @@ class StandardDFT(EmbeddingBase):
         calc_base_ll: ASE FileIOCalculator
             Calculator object for layer 1
         embed_mask: int or list
-            Number of atoms from index 0 in layer 1, or list of reigons assigned 
+            Number of atoms from index 0 in layer 1, or list of reigons assigned
             to each atom (i.e., [1,1,1,2,2,2]) - does nothing for StandardDFT
         calc_base_hl: ASE FileIOCalculator
             Calculator object for layer 2 - does nothing for StandardDFT
@@ -336,13 +344,13 @@ class StandardDFT(EmbeddingBase):
 
         self.calc_names = ["AB_LL"]
 
-        super(StandardDFT, self).__init__(atoms, embed_mask, calc_base_ll, 
+        super(StandardDFT, self).__init__(atoms, embed_mask, calc_base_ll,
                                           calc_base_hl, run_dir=run_dir)
-        low_level_calculator_1 = deepcopy(self.calculator_ll)
+        calc_ll = deepcopy(self.ll_calc)
 
-        low_level_calculator_1.parameters['qm_embedding_calc'] = 1
-        self.set_layer(atoms, self.calc_names[0], low_level_calculator_1, 
-                       embed_mask, ghosts=0, no_scf=False, 
+        calc_ll = self.param_setter_ll.set_full_scf_calc(calc_ll)
+        self.set_layer(atoms, self.calc_names[0], low_level_calc_1,
+                       embed_mask, ghosts=0, no_scf=False,
                        insert_embedding_region=False)
 
     def run(self):
@@ -354,6 +362,9 @@ class StandardDFT(EmbeddingBase):
         root_print(f" -----------======================--------- " )
         root_print(f" Total Energy (AB High-Level): {self.AB_LL.total_energy} eV" )
         root_print(f" -----------======================--------- " )
+
+
+
 
 
 class ProjectionEmbedding(EmbeddingBase):
@@ -412,7 +423,7 @@ class ProjectionEmbedding(EmbeddingBase):
 
         if (truncate_basis_thresh is not None) and (truncate_basis_atoms is not None):
             raise Exception("Please only specific truncate_basis_thresh OR truncate_basis_atoms")
-        
+
         if (truncate_basis_thresh is not None) or (truncate_basis_atoms is not None):
             self.truncate_basis_thresh = truncate_basis_thresh
             self.truncate_basis_atoms = truncate_basis_atoms
@@ -447,7 +458,7 @@ class ProjectionEmbedding(EmbeddingBase):
 
         if self.total_energy_corr == "1storder":
             self.calc_names = ["AB_LL","A_LL","A_HL"]
-        elif self.total_energy_corr == "nonscf": 
+        elif self.total_energy_corr == "nonscf":
             self.calc_names = ["AB_LL","A_LL","A_HL","B_LL"]
         else:
             raise Exception("Invalid entry for total_energy_corr: use '1storder' or 'nonscf' ")
@@ -463,16 +474,22 @@ class ProjectionEmbedding(EmbeddingBase):
         # now keep them persistent in memory, but use far fewer.
         self.gc = gc
 
+        # Set calculator keywords. This is very verbose - maybe the
+        # calculator should be set as an attribute of the param_setter
+        # classes...
         if self.parallel:
-            self.calculator_ll.parameters['scalapack_block_size'] = scalapack_block_size
-            self.calculator_hl.parameters['scalapack_block_size'] = scalapack_block_size
+            self.calculator_ll = \
+                self.param_setter_ll.set_scalapack_blocksize(self.calculator_ll,
+                                                             scalapack_block_size)
+            self.calculator_hl = \
+                self.param_setter_ll.set_scalapack_blocksize(self.calculator_hl,
+                                                             scalapack_block_size)
+        self.calculator_ll = \
+            self.param_setter_ll.override_basis_order(self.calculator_ll)
+        self.calculator_hl = \
+            self.param_setter_hl.override_basis_order(self.calculator_hl)
 
-        self.calculator_ll.parameters['override_default_empty_basis_order']=".true."
-        self.calculator_hl.parameters['override_default_empty_basis_order']=".true."
-
-        self.calculator_ll.parameters['qm_embedding_mo_localise']=".false."
-        self.calculator_hl.parameters['qm_embedding_mo_localise']=".false."
-
+        # Set the projection keywords
         self.projection = projection
         if self.projection == "level-shift":
             root_print(f"MO projection performed with: level-shift")
@@ -486,19 +503,23 @@ class ProjectionEmbedding(EmbeddingBase):
         else:
             raise Exception("Invalid entry for projection: use 'level-shift' or 'huzinaga' ")
 
+        # Copy ASE calculators needed for the AB_LL, A_LL and A_HL calculations
         low_level_calculator_1 = deepcopy(self.calculator_ll)
         low_level_calculator_2 = deepcopy(self.calculator_ll)
         high_level_calculator_1 = deepcopy(self.calculator_hl)
 
+        # Set keywords needed for localisation
         self.localisation = localisation
         if self.localisation == "SPADE":
-            low_level_calculator_2.parameters['qm_embedding_mo_localise']=".false."
+            root_print("Localisation method: SPADE")
         elif self.localisation == "qmcode":
-            low_level_calculator_2.parameters['qm_embedding_mo_localise']=".true."
+            root_print("Localisation method: QM Code")
+            low_level_calculator_1 = \
+                self.param_setter_ll.set_qm_localise(low_level_calculator_1)
         else:
             raise Exception("Invalid entry for localisation: use 'SPADE' or 'qmcode' ")
 
-        
+
         # Determines the BLACS context and descriptors used for the communication
         # and storage of arrays in the NPScal registry structure
         if self.parallel:
@@ -541,7 +562,7 @@ class ProjectionEmbedding(EmbeddingBase):
                        huzinaga=self.flag_huz_sc)
         self.A_HL.abs_truncate = self.abs_truncate
         self.A_HL.truncate = self.truncate
-        
+
         if self.fat_on:
             self.set_layer(atoms, "B_LL", low_level_calculator_1,
                            embed_mask, ghosts=1, no_scf=False,
@@ -568,7 +589,7 @@ class ProjectionEmbedding(EmbeddingBase):
     def calculate_levelshift_projector(self, densmat, overlap):
         """Calculates level-shift projection operator
 
-        Calculate the level-shift based projection operator from 
+        Calculate the level-shift based projection operator from
         Manby et al.[1]:
                     P^{B} = /mu S^{AB} D^{B} S^{AB}
         where S^{AB} is the overlap matrix for the supermolecular system, and
@@ -661,7 +682,7 @@ class ProjectionEmbedding(EmbeddingBase):
         else:
             density_matrix_supersystem = (evecs_occ_ab @ evecs_occ_ab.copy().T)
             density_matrix_subsys_a = (rot_evecs_occ_a @ rot_evecs_occ_a.copy().T)
-            
+
         # I don't think this is needed anymore - density matrices should be synched before this
         # point.
         if not(self.parallel):
@@ -856,7 +877,7 @@ class ProjectionEmbedding(EmbeddingBase):
             emb_ham_a = self.AB_LL.hamiltonian_total - self.A_LL.hamiltonian_total
 
             self.vemb = emb_ham_a
-            
+
             self.A_HL.input_fragment_nelectrons = self.A_pop
             self.A_HL.run_emb_scf(dm_in=densmat_A_LL, emb_pot=emb_ham_a,
                                   sc_huz_dm=densmat_B_LL, sc_huz_ovlp=overlap,
@@ -1098,6 +1119,9 @@ class ProjectionEmbedding(EmbeddingBase):
             self.PB_corr = 0
 
         self.output_data_dict["TOTALENERGY"]["PB_CORR"] = self.PB_corr
+
+        # An FHI-aims specific keyword for extracting total energies
+        # from the post-scf correction
         if "total_energy_method" in self.A_HL.initial_calc.parameters:
             self.subsys_A_highlvl_totalen = self.subsys_A_highlvl_totalen + \
                 self.A_HL.post_scf_corr_energy - self.A_HL.dft_energy
@@ -1221,15 +1245,21 @@ class FrozenDensityEmbedding(EmbeddingBase):
 
         self.run_dir =  run_dir
 
-        initial_calculator.parameters['qm_embedding_type'] = 'frozendensity  write'
-        low_level_calculator.parameters['qm_embedding_type'] = 'frozendensity  read_and_write'
-        high_level_calculator.parameters['qm_embedding_type'] = 'frozendensity  read_and_write'
+        initial_calculator = \
+            self.param_setter_ll.set_embasi_calculation_type(initial_calculator,
+                                                             "frozendensity-write")
+        low_level_calculator = \
+            self.param_setter_ll.set_embasi_calculation_type(low_level_calculator,
+                                                             "frozendensity-readandwrite")
+        initial_calculator = \
+            self.param_setter_ll.set_embasi_calculation_type(high_level_calculator,
+                                                             "frozendensity-readandwrite")
 
-        self.set_layer(atoms, "MU0", initial_calculator, 
+        self.set_layer(atoms, "MU0", initial_calculator,
                        embed_mask, ghosts=2, no_scf=False,
                        insert_embedding_region=False)
 
-        self.set_layer(atoms, "F2A1", low_level_calculator, 
+        self.set_layer(atoms, "F2A1", low_level_calculator,
                        embed_mask, ghosts=2, no_scf=False,
                        insert_embedding_region=False)
 
@@ -1380,12 +1410,9 @@ class ONIOMSubtractiveEmbedding(EmbeddingBase):
 
         self.cluster_hl = cluster_hl
 
-        #self.calculator_ll.parameters['override_default_empty_basis_order']=".true."
-        #self.calculator_hl.parameters['override_default_empty_basis_order']=".true."
-
         low_level_calculator_1 = deepcopy(self.calculator_ll)
         low_level_calculator_2 = deepcopy(self.calculator_ll)
-        
+
         high_level_calculator_1 = deepcopy(self.calculator_hl)
         high_level_calculator_2 = deepcopy(self.calculator_hl)
 
@@ -1394,12 +1421,16 @@ class ONIOMSubtractiveEmbedding(EmbeddingBase):
             high_level_calculator_1.parameters.pop("k_grid")
             high_level_calculator_2.parameters.pop("k_grid")
 
-        low_level_calculator_1.parameters['qm_embedding_calc'] = 1
-        low_level_calculator_2.parameters['qm_embedding_calc'] = 1
-        high_level_calculator_1.parameters['qm_embedding_calc'] = 1
-        high_level_calculator_2.parameters['qm_embedding_calc'] = 1
+        low_level_calculator_1 = \
+            self.param_setter_ll.set_full_scf_calc(low_level_calculator_1)
+        low_level_calculator_2 = \
+            self.param_setter_ll.set_full_scf_calc(low_level_calculator_2)
+        high_level_calculator_1 = \
+            self.param_setter_ll.set_full_scf_calc(high_level_calculator_2)
+        high_level_calculator_2 = \
+            self.param_setter_ll.set_full_scf_calc(high_level_calculator_2)
 
-        self.set_layer(atoms, "AB_LL", low_level_calculator_1, 
+        self.set_layer(atoms, "AB_LL", low_level_calculator_1,
                        embed_mask, ghosts=0, no_scf=False,
                        ctxt_tag=supersys_ctxt_tag,
                        descr_tag=supersys_descr_tag)
@@ -1429,7 +1460,6 @@ class ONIOMSubtractiveEmbedding(EmbeddingBase):
                        ctxt_tag=subsys_ctxt_tag,
                        descr_tag=subsys_descr_tag)
 
-
         if "total_energy_method" in high_level_calculator_2.parameters:
             high_level_calculator_2.parameters['total_energy_method'] = high_level_calculator_2.parameters["xc"]
         self.set_layer(subsys_atoms, "A_HL", high_level_calculator_1,
@@ -1453,8 +1483,6 @@ class ONIOMSubtractiveEmbedding(EmbeddingBase):
     def run(self):
         """ Summary
         The primary driver for ONIOM-like QM/QM embedding using a subtractive scheme.
-        The total energy is evaluated using 
-        
         ...
 
         """
@@ -1492,7 +1520,7 @@ class ONIOMSubtractiveEmbedding(EmbeddingBase):
         self.time_a_highlevel = end - start
 
         # Calculate the total energy of the embedded subsystem A at the high
-        # level of theory without the associated embedding potential.        
+        # level of theory without the associated embedding potential.
         self.A_HL_PP.density_matrix_in = self.A_HL.density_matrices_out[0]
         start = time.time()
         self.A_HL_PP.run()

--- a/embasi/ks_array.py
+++ b/embasi/ks_array.py
@@ -6,14 +6,14 @@ class SpinKpointArray:
     """
     A wrapper around a 2D NumPy array that provides additional indexing
     for spin and k-point dimensions using Pythonic bracket notation.
-    
+
     The internal array has shape (n_spin, n_kpoints, *base_shape) where
     base_shape is the shape of the underlying 2D array.
-    
+
     Indexing works with a tuple: arr[spin, kpoint, i, j]
     - Use None or : to get all elements in a dimension
     - Use integers to select specific indices
-    
+
     Parameters
     ----------
     base_array : tuple indexed array of np.ndarry/NPScal arrays
@@ -24,7 +24,7 @@ class SpinKpointArray:
         Number of k-points (default: 1)
     dtype : np.dtype, optional
         Data type for the array. If None, uses base_array's dtype
-    
+
     Examples
     --------
     >>> arr = SpinKpointArray.zeros((3, 4), n_spin=2, n_kpoints=5)
@@ -34,7 +34,7 @@ class SpinKpointArray:
     >>> arr[0, 2] = 1.0     # Set entire 2D slice
     >>> arr[1, 3, 2, 1] = 5 # Set single element
     """
-    
+
     def __init__(
         self,
         base_array_dict,
@@ -317,7 +317,7 @@ class SpinKpointArray:
         new_data = new_data.N
         self = self.N
         val = val.N
-                    
+
         return new_data
 
     def __mul__(self, val):
@@ -378,7 +378,6 @@ class SpinKpointArray:
                 sum_array = array.copy()
 
         return sum_array
-                
 
 def slice_all_check(slicefuncs):
     for slicefunc in slicefuncs:

--- a/embasi/qmcode_input_directives.py
+++ b/embasi/qmcode_input_directives.py
@@ -1,0 +1,247 @@
+from abc import ABC, abstractmethod
+
+# Valid ASI Flavours
+ASI_flavour = {"Dummy": 0, "FHIaims": 1, "DFTB+": 2}
+
+# Implemented calculators
+implemented_calculators = ["Aims"]
+
+class ase_calc_parameter_setter(ABC):
+
+    def __init__(self):
+        pass
+
+    @property
+    @abstractmethod
+    def asi_flavour(self):
+        return ASI_flavour["Dummy"]
+
+    @abstractmethod
+    def set_ghost_atoms(self, calc, atoms, ghost_list):
+        """Set calculator parameters for setting atoms of a given index as ghost atoms
+
+        Changes the ASE Calculator keywords to accept the keywords to
+        set certain keywords as ghost basis centers.
+
+        Parameters
+        ----------
+        calc : ASECalculator
+            ASE calculator to add parameters.
+        ghost_list : list, len(atoms)
+            A list of booleans to mark which atoms are ghost species.
+        """
+        pass
+
+    @abstractmethod
+    def set_postscf_keyword(self, calc, postscf_method):
+        """Set calculator parameters for setting the keyword for postscf methods
+
+        Changes the ASE Calculator keywords to accept the keywords to
+        the post-scf methods (used for the calling pattern of post-HF)
+        methods in FHI-aims
+
+        Parameters
+        ----------
+        calc : ASECalculator
+            ASE calculator to add parameters.
+        postscf_method : None or str
+            Post-SCF method ran on calculator execution.
+        """
+        pass
+
+    @abstractmethod
+    def set_scalapack_blocksize(self, calc, blacs_blocksize):
+        """Set calculator parameters for setting the ScaLAPACK block size
+
+        Sets the default block size to align the internal NPScal implementation
+
+        Parameters
+        ----------
+        calc : ASECalculator
+            ASE calculator to add parameters.
+        blacs_blocksize : int
+            BLACS blocksize
+        """
+        pass
+
+    @abstractmethod
+    def set_embasi_calculation_type(self, calc, calc_type):
+        """Set calculator parameters for setting the EmbASI calculation control
+           flow keywords
+
+        Sets the default block size to align with the control flow keywords in
+        a given QM code implementation
+
+        Parameters
+        ----------
+        calc : ASECalculator
+            ASE calculator to add parameters.
+        calc_type : str
+            Accepts - 'ks_fullscf', 'total_energy_only', 'full_scf_embed', and 'frozendensity'.
+        """
+        pass
+
+    @abstractmethod
+    def set_noscf_calc_params(self, calc):
+        """Set calculator parameters for running a total energy only calculation
+
+        Changes the ASE Calculator keywords to accept the keywords to
+        skip the SCF cycle and only output the total energy.
+
+        Parameters
+        ----------
+        calc : ASECalculator
+            ASE calculator to add parameters
+        """
+        pass
+
+    @abstractmethod
+    def override_basis_order(self, calc):
+        """Set calculator parameters for overriding basis ordering
+
+        Sets the ASE calculator to ensure that AO basis functions are ordered
+        consistently between calls.
+
+        Parameters
+        ----------
+        calc : ASECalculator
+            ASE calculator to add parameters.
+        """
+        pass
+
+    @abstractmethod
+    def set_qm_localise(self, calc):
+        """Set calculator parameters for performing density matrix localisation
+
+        Sets the ASE calculator keywords to perform a density matrix optimisation
+        and output the density matrix of the embedded and environment subsystems.
+
+        Parameters
+        ----------
+        calc : ASECalculator
+            ASE calculator to add parameters.
+        """
+        pass
+
+    @abstractmethod
+    def set_qm_total_charge(self, calc, charge):
+        """Set calculator parameters for specifying input total charge
+
+        Parameters
+        ----------
+        calc : ASECalculator
+            ASE calculator to add parameters.
+        charge : int
+            Total charge of the system
+        """
+        pass
+
+
+    def set_full_scf_calc(self, calc):
+        calc = self.set_embasi_calculation_type(calc, "ks_fullscf")
+
+        return calc
+
+    def set_no_scf_total_energy_calc(self, calc):
+        calc = self.set_embasi_calculation_type(calc, "total_energy_only")
+
+        return calc
+
+    def set_full_scf_embed_calc(self, calc):
+        calc = self.set_embasi_calculation_type(calc, "full_scf_embed")
+
+        return calc
+
+    def set_frozendensity_calc(self, calc):
+        calc = self.set_embasi_calculation_type(calc, "frozendensity")
+
+        return calc
+
+
+
+class Aims_param_setter(ase_calc_parameter_setter):
+
+    def __init__(self):
+        super(Aims_param_setter, self).__init__()
+
+    @property
+    def asi_flavour(self):
+        return ASI_flavour["FHIaims"]
+
+    def set_noscf_calc_params(self, calc):
+        calc.parameters['charge_mix_param'] = 0.
+        calc.parameters['sc_iter_limit'] = 0
+        self.set_embasi_calculation_type(calc, "total_energy_only")
+
+        return calc
+
+    def set_ghost_atoms(self, calc, atoms, ghost_list):
+        calc.parameters["ghosts"] = ghost_list
+        return calc
+
+    def set_postscf_keyword(self, calc, postscf_method):
+        calc.parameters["total_energy_method"] = postscf_method
+        return calc
+
+    def set_scalapack_blocksize(self, calc, scalapack_blocksize):
+        calc.parameters["scalapack_block_size"] = scalapack_blocksize
+        return calc
+
+    def set_embasi_calculation_type(self, calc, calc_type):
+        if calc_type == "ks_fullscf":
+            calc.parameters["qm_embedding_calc"] = 1
+        elif calc_type == "total_energy_only":
+            calc.parameters["qm_embedding_calc"] = 2
+        elif calc_type == "full_scf_embed":
+            calc.parameters["qm_embedding_calc"] = 3
+        elif calc_type == "frozendensity-write":
+            calc.parameters["qm_embedding_type"] = "frozendensity write"
+        elif calc_type == "frozendensity-readandwrite":
+            calc.parameters["qm_embedding_type"] = "frozendensity read_and_write"
+        else:
+            raise Exception("Only 'ks_fullscf', 'total_energy_only', 'full_scf_embed', and 'frozendensity' supported.")
+
+        return calc
+
+    def override_basis_order(self, calc):
+        calc.parameters['override_default_empty_basis_order']=".true."
+
+        return calc
+
+    def set_qm_localise(self, calc):
+        calc.parameters['qm_embedding_mo_localise']=".true."
+
+        return calc
+
+    def set_qm_total_charge(self, calc, charge):
+        calc.parameters['charge'] = charge
+        return calc
+
+
+
+def ase_calc_parameter_setter(calc):
+    """Gets the ASE Calculator setting class for a given ASE Calculator implementation
+
+    Gets the name of the ASE calculator implementation and returns the
+    object needed to set keywords through the EmbASI calculation
+
+    Parameters
+    ----------
+    calc : ASEIOCalculator
+
+    Raises
+    ------
+    Exception
+        ASE Calulator setter not found
+
+    """
+
+    if type(calc).__name__ not in implemented_calculators:
+        raise Exception("ASE Calculator not implemented.")
+
+    if type(calc).__name__ == "Aims":
+        ASE_parameter_setter = Aims_param_setter()
+    else:
+        raise Exception("ASE Calculator setter not found.")
+
+    return ASE_parameter_setter

--- a/embasi/roothan_hall_eigensolver_scalapack.py
+++ b/embasi/roothan_hall_eigensolver_scalapack.py
@@ -18,7 +18,7 @@ def back_xform_evecs(eigenvectors, xform_mat):
 def sort_eigvals_and_evecs(eigenvalues, eigenvectors):
 
     idx = np.argsort(eigenvalues)
-    
+
     return eigenvalues[idx], eigenvectors[:,idx]
 
 def calculate_occ_mat(eigenvalues, nelec):
@@ -124,7 +124,7 @@ def hamiltonian_eigensolv_parallel(hamiltonian, overlap, nelec, nspins=1, nkpts=
     else:
         occ_mat[(0,0)] = np.zeros(np.size(evals[(0,0)]))
         occ_mat[(0,0)][:int(round(nelec/2))] = 2.0
-        
+
     evecs = SpinKpointArray(evecs, nspins, nkpts)
     evals = SpinKpointArray(evals, nspins, nkpts)
     occ_mat = SpinKpointArray(occ_mat, nspins, nkpts)

--- a/examples/FHIaims/projection_embedding/dimer_meoh_example_parallel.py
+++ b/examples/FHIaims/projection_embedding/dimer_meoh_example_parallel.py
@@ -51,7 +51,6 @@ calc_hl = Aims(xc='PBE', profile=AimsProfile(command="asi-doesnt-need-command"),
     override_initial_charge_check=True,)
 
 # Import dimer from s26 test set
-os.chdir('MeOH_dimer')
 methanol_dimer_idx = s26[22]
 methanol_dimer = create_s22_system(methanol_dimer_idx)
 
@@ -65,9 +64,9 @@ Projection = ProjectionEmbedding(methanol_dimer,
                                  calc_base_ll=calc_ll,
                                  calc_base_hl=calc_hl,
                                  mu_val=1.e+6,
-                                 truncate_basis_thresh=0.001,
+                                 truncate_basis_thresh=0.1,
                                  projection="huzinaga-sc",
-                                 parallel=False)
+                                 parallel=True)
 
 # Now run the simulation!
 root_print('\nRunning MeOH dimer \n')
@@ -87,9 +86,9 @@ Projection = ProjectionEmbedding(methanol_dimer[:6],
                                  calc_base_ll=calc_ll,
                                  calc_base_hl=calc_hl,
                                  mu_val=1.e+6,
-                                 truncate_basis_thresh=0.001,
+                                 truncate_basis_thresh=0.1,
                                  projection="huzinaga-sc",
-                                 parallel=False)
+                                 parallel=True)
 
 # Now run the simulation!
 root_print('\nRunning MeOH dimer \n')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,3 +27,6 @@ dependencies = [
 [project.urls]
 Homepage = "https://github.com/logsdail/EmbASI"
 Issues = "https://github.com/logsdail/EmbASI/issues"
+
+[tool.setuptools]
+packages = ["embasi"]


### PR DESCRIPTION
Remove any straggler FHI-aims keyword inputs and add a general interface for setting keywords for a given ASE calculator. 

A given implementation won't work "out-of-the-box", but the keyword manager `qmcode_input_directives` provides an abstract implementation of the expected functions for modifying the input parameters in the ASE calculator. 